### PR TITLE
fix issue with the quick start docs

### DIFF
--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -15,6 +15,7 @@ You can run TableFlow locally with Docker:
 ```bash
 git clone https://github.com/tableflowhq/tableflow.git
 cd tableflow
+cp .env.example .env
 docker-compose up -d
 ```
 


### PR DESCRIPTION
You need to have POSTGRES_PORT and POSTGRES_PASSWORD set.

Otherwise you will get errors like:

    WARN[0000] The "POSTGRES_USER" variable is not set. Defaulting to a blank string.
    WARN[0000] The "POSTGRES_PASSWORD" variable is not set. Defaulting to a blank string.

    1 error(s) decoding:

    * error decoding 'ports': No port specified: :<empty>

This change instructs users to copy .env.example to .env, which fixes the issue.